### PR TITLE
fix: enforce required attributes and make time optional

### DIFF
--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -13,22 +13,22 @@ class CloudEvent
     /**
      * CloudEvent constructor
      *
+     * @param string $type Event type describing the occurrence (e.g., "com.example.user.created")
+     * @param string $source URI-reference identifying the context in which the event happened
+     * @param string $id Event identifier, unique within the scope of the source
      * @param string $specversion CloudEvents spec version (default: "1.0")
-     * @param string $type Event type that maps to worker (e.g., "v1-stats-usage")
-     * @param string $source Event source (e.g., "imagine")
-     * @param string|null $subject Optional subject, typically project ID
-     * @param string $id Unique event identifier
-     * @param string $time Event timestamp in RFC3339 format
+     * @param string|null $subject Optional subject of the event in the context of the source
+     * @param string|null $time Optional event timestamp in RFC 3339 format
      * @param string $datacontenttype Content type of data (default: "application/json")
      * @param array<string, mixed> $data Event data payload
      */
     public function __construct(
+        public readonly string $type,
+        public readonly string $source,
+        public readonly string $id,
         public readonly string $specversion = '1.0',
-        public readonly string $type = '',
-        public readonly string $source = '',
         public readonly ?string $subject = null,
-        public readonly string $id = '',
-        public readonly string $time = '',
+        public readonly ?string $time = null,
         public readonly string $datacontenttype = 'application/json',
         public readonly array $data = []
     ) {
@@ -43,25 +43,23 @@ class CloudEvent
      */
     public static function fromArray(array $array): self
     {
-        if (!isset($array['specversion'])) {
-            throw new InvalidArgumentException('Missing required field: specversion');
+        foreach (['specversion', 'type', 'source', 'id'] as $field) {
+            if (!isset($array[$field]) || !\is_string($array[$field]) || $array[$field] === '') {
+                throw new InvalidArgumentException('Missing required field: ' . $field);
+            }
         }
 
         if ($array['specversion'] !== '1.0') {
             throw new InvalidArgumentException('Unsupported CloudEvents spec version: ' . $array['specversion']);
         }
 
-        if (!isset($array['type']) || empty($array['type'])) {
-            throw new InvalidArgumentException('Missing required field: type');
-        }
-
         return new self(
-            specversion: $array['specversion'],
             type: $array['type'],
             source: $array['source'],
-            subject: $array['subject'] ?? null,
             id: $array['id'],
-            time: $array['time'],
+            specversion: $array['specversion'],
+            subject: $array['subject'] ?? null,
+            time: $array['time'] ?? null,
             datacontenttype: $array['datacontenttype'] ?? 'application/json',
             data: $array['data'] ?? []
         );
@@ -98,8 +96,24 @@ class CloudEvent
             throw new InvalidArgumentException('Unsupported CloudEvents spec version: ' . $this->specversion);
         }
 
-        if (empty($this->type)) {
+        if ($this->type === '') {
             throw new InvalidArgumentException('Event type is required');
+        }
+
+        if ($this->source === '') {
+            throw new InvalidArgumentException('Event source is required');
+        }
+
+        if ($this->id === '') {
+            throw new InvalidArgumentException('Event id is required');
+        }
+
+        if ($this->subject === '') {
+            throw new InvalidArgumentException('Event subject must not be empty when present');
+        }
+
+        if ($this->time === '') {
+            throw new InvalidArgumentException('Event time must not be empty when present');
         }
 
         return true;

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -33,14 +33,18 @@ class CloudEventTest extends TestCase
 
     public function testConstructorWithDefaults(): void
     {
-        $event = new CloudEvent();
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        );
 
         $this->assertEquals('1.0', $event->specversion);
-        $this->assertEquals('', $event->type);
-        $this->assertEquals('', $event->source);
+        $this->assertEquals('test.event', $event->type);
+        $this->assertEquals('test-service', $event->source);
         $this->assertNull($event->subject);
-        $this->assertEquals('', $event->id);
-        $this->assertEquals('', $event->time);
+        $this->assertEquals('test-id', $event->id);
+        $this->assertNull($event->time);
         $this->assertEquals('application/json', $event->datacontenttype);
         $this->assertEquals([], $event->data);
     }
@@ -76,13 +80,13 @@ class CloudEventTest extends TestCase
             'specversion' => '1.0',
             'type' => 'test.event',
             'source' => 'test-service',
-            'id' => 'test-id',
-            'time' => '2025-11-07T10:00:00Z'
+            'id' => 'test-id'
         ];
 
         $event = CloudEvent::fromArray($data);
 
         $this->assertNull($event->subject);
+        $this->assertNull($event->time);
         $this->assertEquals('application/json', $event->datacontenttype);
         $this->assertEquals([], $event->data);
     }
@@ -106,8 +110,58 @@ class CloudEventTest extends TestCase
         CloudEvent::fromArray([
             'specversion' => '2.0',
             'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id'
+        ]);
+    }
+
+    public function testFromArrayMissingSource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required field: source');
+
+        CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'id' => 'test-id'
+        ]);
+    }
+
+    public function testFromArrayMissingId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required field: id');
+
+        CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
             'source' => 'test-service'
         ]);
+    }
+
+    public function testFromArrayEmptySource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required field: source');
+
+        CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => '',
+            'id' => 'test-id'
+        ]);
+    }
+
+    public function testFromArrayAcceptsZeroStringType(): void
+    {
+        $event = CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => '0',
+            'source' => 'test-service',
+            'id' => 'test-id'
+        ]);
+
+        $this->assertEquals('0', $event->type);
     }
 
     public function testFromArrayMissingType(): void
@@ -218,6 +272,60 @@ class CloudEventTest extends TestCase
         );
 
         $event->validate();
+    }
+
+    public function testValidateEmptySource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event source is required');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: '',
+            id: 'test-id'
+        );
+
+        $event->validate();
+    }
+
+    public function testValidateEmptyId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event id is required');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: ''
+        );
+
+        $event->validate();
+    }
+
+    public function testValidateEmptySubject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event subject must not be empty when present');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            subject: ''
+        );
+
+        $event->validate();
+    }
+
+    public function testValidateWithoutTime(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        );
+
+        $this->assertTrue($event->validate());
     }
 
     public function testRoundTrip(): void


### PR DESCRIPTION
## What

Aligns required/optional attribute handling with the CloudEvents v1.0 spec.

- `type`, `source` and `id` are now required constructor parameters — the spec requires them to be non-empty, so defaults that produced invalid events are gone
- `time` is now nullable (it is **optional** per spec) instead of defaulting to an empty string
- `fromArray()` guards all required fields, so a missing `source` or `id` throws a clean `InvalidArgumentException` instead of a PHP `TypeError`
- `validate()` now checks `source`, `id`, `subject` and `time`, not just `specversion` and `type`
- Replaced `empty()` checks with strict comparisons so the valid type `"0"` is no longer rejected

## Why

Per [the spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md), `id`, `source`, `specversion` and `type` are REQUIRED non-empty attributes, while `time` is OPTIONAL. Previously an event without `time` crashed `fromArray()`, while events missing `source`/`id` passed `validate()`.

⚠️ Breaking: positional constructor calls change (named arguments unaffected); `new CloudEvent()` without arguments no longer works.

Part 1/7 of a spec-compliance PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)