### PR TITLE
fix: allow any data type and omit absent optional attributes

### DIFF
--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -133,7 +133,7 @@ class CloudEvent
             throw new InvalidArgumentException('Event time must not be empty when present');
         }
 
-        if ($this->datacontenttype === '') {
+        if ($this->datacontenttype !== null && \trim($this->datacontenttype) === '') {
             throw new InvalidArgumentException('Event datacontenttype must not be empty when present');
         }
 

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -19,8 +19,8 @@ class CloudEvent
      * @param string $specversion CloudEvents spec version (default: "1.0")
      * @param string|null $subject Optional subject of the event in the context of the source
      * @param string|null $time Optional event timestamp in RFC 3339 format
-     * @param string $datacontenttype Content type of data (default: "application/json")
-     * @param array<string, mixed> $data Event data payload
+     * @param string|null $datacontenttype Optional content type of data (RFC 2046, e.g., "application/json")
+     * @param mixed $data Optional event payload of any type
      */
     public function __construct(
         public readonly string $type,
@@ -29,8 +29,8 @@ class CloudEvent
         public readonly string $specversion = '1.0',
         public readonly ?string $subject = null,
         public readonly ?string $time = null,
-        public readonly string $datacontenttype = 'application/json',
-        public readonly array $data = []
+        public readonly ?string $datacontenttype = null,
+        public readonly mixed $data = null
     ) {
     }
 
@@ -60,28 +60,45 @@ class CloudEvent
             specversion: $array['specversion'],
             subject: $array['subject'] ?? null,
             time: $array['time'] ?? null,
-            datacontenttype: $array['datacontenttype'] ?? 'application/json',
-            data: $array['data'] ?? []
+            datacontenttype: $array['datacontenttype'] ?? null,
+            data: $array['data'] ?? null
         );
     }
 
     /**
      * Convert CloudEvent to array
      *
+     * Optional attributes that are absent are omitted, since the spec
+     * does not allow null attribute values.
+     *
      * @return array<string, mixed>
      */
     public function toArray(): array
     {
-        return [
+        $array = [
             'specversion' => $this->specversion,
             'type' => $this->type,
             'source' => $this->source,
-            'subject' => $this->subject,
             'id' => $this->id,
-            'time' => $this->time,
-            'datacontenttype' => $this->datacontenttype,
-            'data' => $this->data
         ];
+
+        if ($this->subject !== null) {
+            $array['subject'] = $this->subject;
+        }
+
+        if ($this->time !== null) {
+            $array['time'] = $this->time;
+        }
+
+        if ($this->datacontenttype !== null) {
+            $array['datacontenttype'] = $this->datacontenttype;
+        }
+
+        if ($this->data !== null) {
+            $array['data'] = $this->data;
+        }
+
+        return $array;
     }
 
     /**
@@ -114,6 +131,10 @@ class CloudEvent
 
         if ($this->time === '') {
             throw new InvalidArgumentException('Event time must not be empty when present');
+        }
+
+        if ($this->datacontenttype === '') {
+            throw new InvalidArgumentException('Event datacontenttype must not be empty when present');
         }
 
         return true;

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -45,8 +45,8 @@ class CloudEventTest extends TestCase
         $this->assertNull($event->subject);
         $this->assertEquals('test-id', $event->id);
         $this->assertNull($event->time);
-        $this->assertEquals('application/json', $event->datacontenttype);
-        $this->assertEquals([], $event->data);
+        $this->assertNull($event->datacontenttype);
+        $this->assertNull($event->data);
     }
 
     public function testFromArray(): void
@@ -87,8 +87,8 @@ class CloudEventTest extends TestCase
 
         $this->assertNull($event->subject);
         $this->assertNull($event->time);
-        $this->assertEquals('application/json', $event->datacontenttype);
-        $this->assertEquals([], $event->data);
+        $this->assertNull($event->datacontenttype);
+        $this->assertNull($event->data);
     }
 
     public function testFromArrayMissingSpecversion(): void
@@ -214,19 +214,63 @@ class CloudEventTest extends TestCase
         ], $array);
     }
 
-    public function testToArrayWithNullSubject(): void
+    public function testToArrayOmitsAbsentOptionalAttributes(): void
     {
         $event = new CloudEvent(
-            specversion: '1.0',
             type: 'test.event',
             source: 'test-service',
-            id: 'test-id',
-            time: '2025-11-07T10:00:00Z'
+            id: 'test-id'
         );
 
         $array = $event->toArray();
 
-        $this->assertNull($array['subject']);
+        $this->assertEquals([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id'
+        ], $array);
+        $this->assertArrayNotHasKey('subject', $array);
+        $this->assertArrayNotHasKey('time', $array);
+        $this->assertArrayNotHasKey('datacontenttype', $array);
+        $this->assertArrayNotHasKey('data', $array);
+    }
+
+    public function testDataAcceptsAnyType(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            datacontenttype: 'text/plain',
+            data: 'plain text payload'
+        );
+
+        $this->assertEquals('plain text payload', $event->data);
+        $this->assertEquals('plain text payload', $event->toArray()['data']);
+
+        $event = CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id',
+            'data' => 42
+        ]);
+
+        $this->assertEquals(42, $event->data);
+    }
+
+    public function testFromArrayDoesNotFabricateDatacontenttype(): void
+    {
+        $event = CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id'
+        ]);
+
+        $this->assertNull($event->datacontenttype);
+        $this->assertArrayNotHasKey('datacontenttype', $event->toArray());
     }
 
     public function testValidate(): void

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -260,6 +260,21 @@ class CloudEventTest extends TestCase
         $this->assertEquals(42, $event->data);
     }
 
+    public function testValidateRejectsBlankDatacontenttype(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event datacontenttype must not be empty when present');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            datacontenttype: '   '
+        );
+
+        $event->validate();
+    }
+
     public function testFromArrayDoesNotFabricateDatacontenttype(): void
     {
         $event = CloudEvent::fromArray([


### PR DESCRIPTION
## What

- `data` is now `mixed` (`null` when absent) instead of being forced to an array
- `datacontenttype` no longer defaults to `application/json` — it is optional per spec, and `fromArray()` no longer fabricates it when the input omits it
- `toArray()` omits absent optional attributes instead of emitting `subject => null` (the spec explicitly disallows null attribute values) and `data => []`
- `validate()` rejects an empty `datacontenttype`

## Why

Per the CloudEvents v1.0 spec, `data` may be of **any** type — a JSON object, plain text, a number, or binary. Forcing an array made first-class use cases like `data: "plain text"` with `datacontenttype: text/plain` impossible, and round-tripping through `fromArray()`/`toArray()` added attributes the producer never set.

Stacked on #6 — part 2/7 of a spec-compliance PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)