### PR TITLE
feat: add dataschema context attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ The `CloudEvent` class supports the following properties according to the CloudE
 - **id** (required): Unique identifier for the event
 - **time** (required): Timestamp when the event occurred (RFC3339 format)
 - **datacontenttype** (optional): Content type of the data field (default: "application/json")
+- **dataschema** (optional): URI identifying the schema that the data field adheres to
 - **data** (required): Event payload as an array
+
+Optional attributes are omitted from `toArray()` when absent, since the spec does not allow null attribute values. When present, they must not be empty — `validate()` rejects an empty `dataschema`.
 
 ## Use Cases
 

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -20,8 +20,8 @@ class CloudEvent
      * @param string|null $subject Optional subject of the event in the context of the source
      * @param string|null $time Optional event timestamp in RFC 3339 format
      * @param string|null $datacontenttype Optional content type of data (RFC 2046, e.g., "application/json")
-     * @param string|null $dataschema Optional URI identifying the schema that data adheres to
      * @param mixed $data Optional event payload of any type
+     * @param string|null $dataschema Optional URI identifying the schema that data adheres to
      */
     public function __construct(
         public readonly string $type,
@@ -31,8 +31,8 @@ class CloudEvent
         public readonly ?string $subject = null,
         public readonly ?string $time = null,
         public readonly ?string $datacontenttype = null,
-        public readonly ?string $dataschema = null,
-        public readonly mixed $data = null
+        public readonly mixed $data = null,
+        public readonly ?string $dataschema = null
     ) {
     }
 
@@ -63,8 +63,8 @@ class CloudEvent
             subject: $array['subject'] ?? null,
             time: $array['time'] ?? null,
             datacontenttype: $array['datacontenttype'] ?? null,
-            dataschema: $array['dataschema'] ?? null,
-            data: $array['data'] ?? null
+            data: $array['data'] ?? null,
+            dataschema: $array['dataschema'] ?? null
         );
     }
 

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -20,6 +20,7 @@ class CloudEvent
      * @param string|null $subject Optional subject of the event in the context of the source
      * @param string|null $time Optional event timestamp in RFC 3339 format
      * @param string|null $datacontenttype Optional content type of data (RFC 2046, e.g., "application/json")
+     * @param string|null $dataschema Optional URI identifying the schema that data adheres to
      * @param mixed $data Optional event payload of any type
      */
     public function __construct(
@@ -30,6 +31,7 @@ class CloudEvent
         public readonly ?string $subject = null,
         public readonly ?string $time = null,
         public readonly ?string $datacontenttype = null,
+        public readonly ?string $dataschema = null,
         public readonly mixed $data = null
     ) {
     }
@@ -61,6 +63,7 @@ class CloudEvent
             subject: $array['subject'] ?? null,
             time: $array['time'] ?? null,
             datacontenttype: $array['datacontenttype'] ?? null,
+            dataschema: $array['dataschema'] ?? null,
             data: $array['data'] ?? null
         );
     }
@@ -92,6 +95,10 @@ class CloudEvent
 
         if ($this->datacontenttype !== null) {
             $array['datacontenttype'] = $this->datacontenttype;
+        }
+
+        if ($this->dataschema !== null) {
+            $array['dataschema'] = $this->dataschema;
         }
 
         if ($this->data !== null) {
@@ -135,6 +142,10 @@ class CloudEvent
 
         if ($this->datacontenttype === '') {
             throw new InvalidArgumentException('Event datacontenttype must not be empty when present');
+        }
+
+        if ($this->dataschema === '') {
+            throw new InvalidArgumentException('Event dataschema must not be empty when present');
         }
 
         return true;

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -260,6 +260,50 @@ class CloudEventTest extends TestCase
         $this->assertEquals(42, $event->data);
     }
 
+    public function testDataschema(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            dataschema: 'https://example.com/schemas/user.json'
+        );
+
+        $this->assertEquals('https://example.com/schemas/user.json', $event->dataschema);
+        $this->assertEquals('https://example.com/schemas/user.json', $event->toArray()['dataschema']);
+        $this->assertTrue($event->validate());
+
+        $restored = CloudEvent::fromArray($event->toArray());
+        $this->assertEquals($event->dataschema, $restored->dataschema);
+    }
+
+    public function testDataschemaAbsent(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        );
+
+        $this->assertNull($event->dataschema);
+        $this->assertArrayNotHasKey('dataschema', $event->toArray());
+    }
+
+    public function testValidateEmptyDataschema(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event dataschema must not be empty when present');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            dataschema: ''
+        );
+
+        $event->validate();
+    }
+
     public function testFromArrayDoesNotFabricateDatacontenttype(): void
     {
         $event = CloudEvent::fromArray([


### PR DESCRIPTION
## What

Adds the optional `dataschema` context attribute — a URI identifying the schema that `data` adheres to. It participates in `fromArray()`/`toArray()` round-trips, is omitted from output when absent, and `validate()` rejects it when present but empty.

## Why

`dataschema` is one of the optional context attributes defined by the CloudEvents v1.0 spec and was missing entirely from the class.

Stacked on #7 — part 3/7 of a spec-compliance PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)