### PR TITLE
feat: add extension attribute support

### DIFF
--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -11,6 +11,22 @@ use InvalidArgumentException;
 class CloudEvent
 {
     /**
+     * Names reserved for core context attributes, which extension
+     * attributes must not use.
+     */
+    private const RESERVED_ATTRIBUTES = [
+        'specversion',
+        'type',
+        'source',
+        'id',
+        'subject',
+        'time',
+        'datacontenttype',
+        'dataschema',
+        'data',
+    ];
+
+    /**
      * CloudEvent constructor
      *
      * @param string $type Event type describing the occurrence (e.g., "com.example.user.created")
@@ -22,6 +38,7 @@ class CloudEvent
      * @param string|null $datacontenttype Optional content type of data (RFC 2046, e.g., "application/json")
      * @param string|null $dataschema Optional URI identifying the schema that data adheres to
      * @param mixed $data Optional event payload of any type
+     * @param array<string, mixed> $extensions Extension attributes (lowercase alphanumeric names, boolean/integer/string values)
      */
     public function __construct(
         public readonly string $type,
@@ -32,8 +49,46 @@ class CloudEvent
         public readonly ?string $time = null,
         public readonly ?string $datacontenttype = null,
         public readonly ?string $dataschema = null,
-        public readonly mixed $data = null
+        public readonly mixed $data = null,
+        public readonly array $extensions = []
     ) {
+    }
+
+    /**
+     * Return a copy of the event with the given extension attribute set
+     *
+     * @param string $name
+     * @param bool|int|string $value
+     * @return self
+     * @throws InvalidArgumentException
+     */
+    public function withExtension(string $name, bool|int|string $value): self
+    {
+        self::assertValidExtensionName($name);
+
+        return new self(
+            type: $this->type,
+            source: $this->source,
+            id: $this->id,
+            specversion: $this->specversion,
+            subject: $this->subject,
+            time: $this->time,
+            datacontenttype: $this->datacontenttype,
+            dataschema: $this->dataschema,
+            data: $this->data,
+            extensions: \array_merge($this->extensions, [$name => $value])
+        );
+    }
+
+    /**
+     * Get an extension attribute value, or null when not set
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function getExtension(string $name): mixed
+    {
+        return $this->extensions[$name] ?? null;
     }
 
     /**
@@ -64,7 +119,8 @@ class CloudEvent
             time: $array['time'] ?? null,
             datacontenttype: $array['datacontenttype'] ?? null,
             dataschema: $array['dataschema'] ?? null,
-            data: $array['data'] ?? null
+            data: $array['data'] ?? null,
+            extensions: \array_diff_key($array, \array_flip(self::RESERVED_ATTRIBUTES))
         );
     }
 
@@ -105,7 +161,7 @@ class CloudEvent
             $array['data'] = $this->data;
         }
 
-        return $array;
+        return $array + $this->extensions;
     }
 
     /**
@@ -148,6 +204,32 @@ class CloudEvent
             throw new InvalidArgumentException('Event dataschema must not be empty when present');
         }
 
+        foreach ($this->extensions as $name => $value) {
+            self::assertValidExtensionName((string) $name);
+
+            if (!\is_bool($value) && !\is_int($value) && !\is_string($value)) {
+                throw new InvalidArgumentException('Extension attribute "' . $name . '" must be a boolean, integer or string');
+            }
+        }
+
         return true;
+    }
+
+    /**
+     * Assert that a name is a valid, non-reserved extension attribute name
+     *
+     * @param string $name
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    private static function assertValidExtensionName(string $name): void
+    {
+        if (!\preg_match('/^[a-z0-9]+$/', $name)) {
+            throw new InvalidArgumentException('Extension attribute name must contain only lowercase letters and digits: ' . $name);
+        }
+
+        if (\in_array($name, self::RESERVED_ATTRIBUTES, true)) {
+            throw new InvalidArgumentException('Extension attribute name conflicts with a core attribute: ' . $name);
+        }
     }
 }

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -110,6 +110,21 @@ class CloudEvent
             throw new InvalidArgumentException('Unsupported CloudEvents spec version: ' . $array['specversion']);
         }
 
+        $extensions = \array_diff_key($array, \array_flip(self::RESERVED_ATTRIBUTES));
+
+        foreach ($extensions as $name => $value) {
+            if ($value === null) {
+                unset($extensions[$name]);
+                continue;
+            }
+
+            self::assertValidExtensionName((string) $name);
+
+            if (!\is_bool($value) && !\is_int($value) && !\is_string($value)) {
+                throw new InvalidArgumentException('Extension attribute "' . $name . '" must be a boolean, integer or string');
+            }
+        }
+
         return new self(
             type: $array['type'],
             source: $array['source'],
@@ -120,7 +135,7 @@ class CloudEvent
             datacontenttype: $array['datacontenttype'] ?? null,
             data: $array['data'] ?? null,
             dataschema: $array['dataschema'] ?? null,
-            extensions: \array_diff_key($array, \array_flip(self::RESERVED_ATTRIBUTES))
+            extensions: $extensions
         );
     }
 

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -55,43 +55,6 @@ class CloudEvent
     }
 
     /**
-     * Return a copy of the event with the given extension attribute set
-     *
-     * @param string $name
-     * @param bool|int|string $value
-     * @return self
-     * @throws InvalidArgumentException
-     */
-    public function withExtension(string $name, bool|int|string $value): self
-    {
-        self::assertValidExtensionName($name);
-
-        return new self(
-            type: $this->type,
-            source: $this->source,
-            id: $this->id,
-            specversion: $this->specversion,
-            subject: $this->subject,
-            time: $this->time,
-            datacontenttype: $this->datacontenttype,
-            dataschema: $this->dataschema,
-            data: $this->data,
-            extensions: \array_merge($this->extensions, [$name => $value])
-        );
-    }
-
-    /**
-     * Get an extension attribute value, or null when not set
-     *
-     * @param string $name
-     * @return mixed
-     */
-    public function getExtension(string $name): mixed
-    {
-        return $this->extensions[$name] ?? null;
-    }
-
-    /**
      * Create CloudEvent from array
      *
      * @param array<string, mixed> $array

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -481,6 +481,48 @@ class CloudEventTest extends TestCase
         $this->assertEquals('00-abc-def-01', $event->getExtension('traceparent'));
     }
 
+    public function testFromArrayRejectsInvalidExtensionName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute name must contain only lowercase letters and digits');
+
+        CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id',
+            'Trace_Parent' => 'value'
+        ]);
+    }
+
+    public function testFromArrayRejectsInvalidExtensionValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute "myext" must be a boolean, integer or string');
+
+        CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id',
+            'myext' => ['nested' => 'array']
+        ]);
+    }
+
+    public function testFromArrayDropsNullExtensions(): void
+    {
+        $event = CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id',
+            'traceparent' => null
+        ]);
+
+        $this->assertEquals([], $event->extensions);
+        $this->assertArrayNotHasKey('traceparent', $event->toArray());
+    }
+
     public function testWithExtensionRejectsInvalidName(): void
     {
         $event = new CloudEvent(

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -416,6 +416,112 @@ class CloudEventTest extends TestCase
         $this->assertTrue($event->validate());
     }
 
+    public function testWithExtension(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        );
+
+        $extended = $event
+            ->withExtension('traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+            ->withExtension('sequence', 42)
+            ->withExtension('sampled', true);
+
+        $this->assertEquals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01', $extended->getExtension('traceparent'));
+        $this->assertEquals(42, $extended->getExtension('sequence'));
+        $this->assertTrue($extended->getExtension('sampled'));
+        $this->assertTrue($extended->validate());
+
+        $this->assertEquals([], $event->extensions);
+        $this->assertNull($event->getExtension('traceparent'));
+    }
+
+    public function testToArrayIncludesExtensions(): void
+    {
+        $event = (new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        ))->withExtension('partitionkey', 'shard-1');
+
+        $array = $event->toArray();
+
+        $this->assertEquals('shard-1', $array['partitionkey']);
+    }
+
+    public function testFromArrayCollectsExtensions(): void
+    {
+        $event = CloudEvent::fromArray([
+            'specversion' => '1.0',
+            'type' => 'test.event',
+            'source' => 'test-service',
+            'id' => 'test-id',
+            'traceparent' => '00-abc-def-01',
+            'sequence' => 7
+        ]);
+
+        $this->assertEquals(['traceparent' => '00-abc-def-01', 'sequence' => 7], $event->extensions);
+        $this->assertEquals('00-abc-def-01', $event->getExtension('traceparent'));
+    }
+
+    public function testWithExtensionRejectsInvalidName(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute name must contain only lowercase letters and digits');
+
+        $event->withExtension('Trace_Parent', 'value');
+    }
+
+    public function testWithExtensionRejectsReservedName(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute name conflicts with a core attribute: data');
+
+        $event->withExtension('data', 'value');
+    }
+
+    public function testValidateRejectsInvalidExtensionValue(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            extensions: ['myext' => ['nested' => 'array']]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute "myext" must be a boolean, integer or string');
+
+        $event->validate();
+    }
+
+    public function testExtensionRoundTrip(): void
+    {
+        $original = (new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id'
+        ))->withExtension('traceparent', '00-abc-def-01');
+
+        $restored = CloudEvent::fromArray($original->toArray());
+
+        $this->assertEquals($original->extensions, $restored->extensions);
+    }
+
     public function testRoundTrip(): void
     {
         $original = new CloudEvent(

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -431,7 +431,26 @@ class CloudEventTest extends TestCase
         $this->assertTrue($event->validate());
     }
 
-    public function testWithExtension(): void
+    public function testExtensions(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            extensions: [
+                'traceparent' => '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+                'sequence' => 42,
+                'sampled' => true,
+            ]
+        );
+
+        $this->assertEquals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01', $event->extensions['traceparent']);
+        $this->assertEquals(42, $event->extensions['sequence']);
+        $this->assertTrue($event->extensions['sampled']);
+        $this->assertTrue($event->validate());
+    }
+
+    public function testExtensionsDefaultToEmpty(): void
     {
         $event = new CloudEvent(
             type: 'test.event',
@@ -439,27 +458,17 @@ class CloudEventTest extends TestCase
             id: 'test-id'
         );
 
-        $extended = $event
-            ->withExtension('traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
-            ->withExtension('sequence', 42)
-            ->withExtension('sampled', true);
-
-        $this->assertEquals('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01', $extended->getExtension('traceparent'));
-        $this->assertEquals(42, $extended->getExtension('sequence'));
-        $this->assertTrue($extended->getExtension('sampled'));
-        $this->assertTrue($extended->validate());
-
         $this->assertEquals([], $event->extensions);
-        $this->assertNull($event->getExtension('traceparent'));
     }
 
     public function testToArrayIncludesExtensions(): void
     {
-        $event = (new CloudEvent(
+        $event = new CloudEvent(
             type: 'test.event',
             source: 'test-service',
-            id: 'test-id'
-        ))->withExtension('partitionkey', 'shard-1');
+            id: 'test-id',
+            extensions: ['partitionkey' => 'shard-1']
+        );
 
         $array = $event->toArray();
 
@@ -478,7 +487,7 @@ class CloudEventTest extends TestCase
         ]);
 
         $this->assertEquals(['traceparent' => '00-abc-def-01', 'sequence' => 7], $event->extensions);
-        $this->assertEquals('00-abc-def-01', $event->getExtension('traceparent'));
+        $this->assertEquals('00-abc-def-01', $event->extensions['traceparent']);
     }
 
     public function testFromArrayRejectsInvalidExtensionName(): void
@@ -523,32 +532,34 @@ class CloudEventTest extends TestCase
         $this->assertArrayNotHasKey('traceparent', $event->toArray());
     }
 
-    public function testWithExtensionRejectsInvalidName(): void
+    public function testValidateRejectsInvalidExtensionName(): void
     {
         $event = new CloudEvent(
             type: 'test.event',
             source: 'test-service',
-            id: 'test-id'
+            id: 'test-id',
+            extensions: ['Trace_Parent' => 'value']
         );
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Extension attribute name must contain only lowercase letters and digits');
 
-        $event->withExtension('Trace_Parent', 'value');
+        $event->validate();
     }
 
-    public function testWithExtensionRejectsReservedName(): void
+    public function testValidateRejectsReservedExtensionName(): void
     {
         $event = new CloudEvent(
             type: 'test.event',
             source: 'test-service',
-            id: 'test-id'
+            id: 'test-id',
+            extensions: ['data' => 'value']
         );
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Extension attribute name conflicts with a core attribute: data');
 
-        $event->withExtension('data', 'value');
+        $event->validate();
     }
 
     public function testValidateRejectsInvalidExtensionValue(): void
@@ -568,11 +579,12 @@ class CloudEventTest extends TestCase
 
     public function testExtensionRoundTrip(): void
     {
-        $original = (new CloudEvent(
+        $original = new CloudEvent(
             type: 'test.event',
             source: 'test-service',
-            id: 'test-id'
-        ))->withExtension('traceparent', '00-abc-def-01');
+            id: 'test-id',
+            extensions: ['traceparent' => '00-abc-def-01']
+        );
 
         $restored = CloudEvent::fromArray($original->toArray());
 


### PR DESCRIPTION
## What

Implements the CloudEvents v1.0 extension attribute mechanism (`traceparent`, `partitionkey`, …):

- Extensions are passed at construction time via the readonly `extensions` array and read directly from the property (`$event->extensions['traceparent'] ?? null`) — no getters or withers, per team convention
- `fromArray()` collects unknown keys as extension attributes instead of dropping them silently, enforcing the naming and value-type rules and dropping null values (the JSON format defines null as equivalent to absent)
- `toArray()` serializes extensions alongside core attributes
- `validate()` enforces the spec naming rules (lowercase alphanumeric, no collision with core attribute names) and the boolean/integer/string value types

## Why

Extensions are the spec's core extensibility mechanism and the biggest interoperability gap — events carrying tracing or partitioning metadata previously lost it on parse.

Stacked on #8 — part 4/7 of a spec-compliance PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)