### PR TITLE
feat: validate attribute formats in validate()

### DIFF
--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -366,7 +366,23 @@ class CloudEvent
         $unreservedSub = "A-Za-z0-9\\-._~!$&'()*+,;=";
         $pchar = "(?:[{$unreservedSub}:@]|{$pct})";
         $userinfo = "(?:[{$unreservedSub}:]|{$pct})*";
-        $ipLiteral = '\[[0-9A-Fa-f:.]+\]';
+        $h16 = '[0-9A-Fa-f]{1,4}';
+        $decOctet = '(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])';
+        $ipv4 = "{$decOctet}(?:\\.{$decOctet}){3}";
+        $ls32 = "(?:{$h16}:{$h16}|{$ipv4})";
+        $ipv6 = '(?:'
+            . "(?:{$h16}:){6}{$ls32}"
+            . "|::(?:{$h16}:){5}{$ls32}"
+            . "|(?:{$h16})?::(?:{$h16}:){4}{$ls32}"
+            . "|(?:(?:{$h16}:)?{$h16})?::(?:{$h16}:){3}{$ls32}"
+            . "|(?:(?:{$h16}:){0,2}{$h16})?::(?:{$h16}:){2}{$ls32}"
+            . "|(?:(?:{$h16}:){0,3}{$h16})?::{$h16}:{$ls32}"
+            . "|(?:(?:{$h16}:){0,4}{$h16})?::{$ls32}"
+            . "|(?:(?:{$h16}:){0,5}{$h16})?::{$h16}"
+            . "|(?:(?:{$h16}:){0,6}{$h16})?::"
+            . ')';
+        $ipvFuture = "[vV][0-9A-Fa-f]+\\.[{$unreservedSub}:]+";
+        $ipLiteral = "\\[(?:{$ipv6}|{$ipvFuture})\\]";
         $regName = "(?:[{$unreservedSub}]|{$pct})*";
         $authority = "(?:{$userinfo}@)?(?:{$ipLiteral}|{$regName})(?::[0-9]*)?";
         $pathAbempty = "(?:/{$pchar}*)*";
@@ -413,7 +429,10 @@ class CloudEvent
     /**
      * Check that a string is an RFC 2046 media type such as
      * "application/json" or "text/plain; charset=utf-8", with every
-     * parameter a token=token or token=quoted-string pair
+     * parameter a token=token or token=quoted-string pair. Quoted
+     * strings may contain tab, space and visible characters, with
+     * backslash escapes for '"' and '\', but no other control
+     * characters.
      *
      * @param string $type
      * @return bool
@@ -421,7 +440,9 @@ class CloudEvent
     private static function isValidMediaType(string $type): bool
     {
         $token = "[0-9A-Za-z!#$%&'*+.^_`|~-]+";
-        $value = "(?:{$token}|\"(?:[^\"\\\\]|\\\\.)*\")";
+        $qdtext = '[\t \x21\x23-\x5B\x5D-\x7E]';
+        $quotedPair = '\\\\[\t\x20-\x7E]';
+        $value = "(?:{$token}|\"(?:{$qdtext}|{$quotedPair})*\")";
 
         return \preg_match('{^' . $token . '/' . $token . '(?:\s*;\s*' . $token . '=' . $value . ')*$}', $type) === 1;
     }

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -184,7 +184,9 @@ class CloudEvent
      * Create CloudEvent from its JSON event format representation
      *
      * Binary payloads carried in the data_base64 member are decoded
-     * into data.
+     * into data. JSON objects inside data are decoded as stdClass so
+     * that object and array payloads keep their JSON type when
+     * re-encoded (e.g., an empty object stays {} instead of []).
      *
      * @see https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md
      *
@@ -195,14 +197,16 @@ class CloudEvent
     public static function fromJson(string $json): self
     {
         try {
-            $decoded = \json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+            $raw = \json_decode($json, false, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new InvalidArgumentException('Invalid CloudEvent JSON: ' . $e->getMessage(), 0, $e);
         }
 
-        if (!\is_array($decoded)) {
+        if (!$raw instanceof \stdClass) {
             throw new InvalidArgumentException('CloudEvent JSON must decode to an object');
         }
+
+        $decoded = \get_object_vars($raw);
 
         if (\array_key_exists('data_base64', $decoded)) {
             if (\array_key_exists('data', $decoded)) {

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -355,37 +355,65 @@ class CloudEvent
     }
 
     /**
-     * Check that a string only uses characters RFC 3986 allows in a
-     * URI-reference and that every percent sign starts a valid
-     * percent-encoded triplet
+     * Build the RFC 3986 grammar as regex subpatterns for a URI and a
+     * relative reference
+     *
+     * @return array{uri: string, relative: string}
+     */
+    private static function uriGrammar(): array
+    {
+        $pct = '%[0-9A-Fa-f]{2}';
+        $unreservedSub = "A-Za-z0-9\\-._~!$&'()*+,;=";
+        $pchar = "(?:[{$unreservedSub}:@]|{$pct})";
+        $userinfo = "(?:[{$unreservedSub}:]|{$pct})*";
+        $ipLiteral = '\[[0-9A-Fa-f:.]+\]';
+        $regName = "(?:[{$unreservedSub}]|{$pct})*";
+        $authority = "(?:{$userinfo}@)?(?:{$ipLiteral}|{$regName})(?::[0-9]*)?";
+        $pathAbempty = "(?:/{$pchar}*)*";
+        $pathAbsolute = "/(?:{$pchar}+(?:/{$pchar}*)*)?";
+        $pathRootless = "{$pchar}+(?:/{$pchar}*)*";
+        $pathNoscheme = "(?:[{$unreservedSub}@]|{$pct})+(?:/{$pchar}*)*";
+        $queryFragment = "(?:{$pchar}|[/?])*";
+        $scheme = '[A-Za-z][A-Za-z0-9+.\-]*';
+
+        return [
+            'uri' => "{$scheme}:(?://{$authority}{$pathAbempty}|{$pathAbsolute}|{$pathRootless})?(?:\\?{$queryFragment})?(?:#{$queryFragment})?",
+            'relative' => "(?://{$authority}{$pathAbempty}|{$pathAbsolute}|{$pathNoscheme})?(?:\\?{$queryFragment})?(?:#{$queryFragment})?",
+        ];
+    }
+
+    /**
+     * Check that a string matches the RFC 3986 URI-reference grammar
+     * (an absolute URI or a relative reference)
      *
      * @param string $uri
      * @return bool
      */
     private static function isValidUriReference(string $uri): bool
     {
-        if (\preg_match('/^[A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=%]*$/', $uri) !== 1) {
-            return false;
-        }
+        $grammar = self::uriGrammar();
 
-        return \preg_match('/%(?![0-9A-Fa-f]{2})/', $uri) !== 1;
+        return \preg_match('"^(?:' . $grammar['uri'] . '|' . $grammar['relative'] . ')$"', $uri) === 1;
     }
 
     /**
-     * Check that a string is an absolute URI (has a scheme) with valid
-     * URI characters
+     * Check that a string matches the RFC 3986 URI grammar (absolute,
+     * with a scheme)
      *
      * @param string $uri
      * @return bool
      */
     private static function isValidUri(string $uri): bool
     {
-        return \preg_match('/^[A-Za-z][A-Za-z0-9+.\-]*:/', $uri) === 1 && self::isValidUriReference($uri);
+        $grammar = self::uriGrammar();
+
+        return \preg_match('"^' . $grammar['uri'] . '$"', $uri) === 1;
     }
 
     /**
      * Check that a string is an RFC 2046 media type such as
-     * "application/json" or "text/plain; charset=utf-8"
+     * "application/json" or "text/plain; charset=utf-8", with every
+     * parameter a token=token or token=quoted-string pair
      *
      * @param string $type
      * @return bool
@@ -393,8 +421,9 @@ class CloudEvent
     private static function isValidMediaType(string $type): bool
     {
         $token = "[0-9A-Za-z!#$%&'*+.^_`|~-]+";
+        $value = "(?:{$token}|\"(?:[^\"\\\\]|\\\\.)*\")";
 
-        return \preg_match('{^' . $token . '/' . $token . '(\s*;.*)?$}', $type) === 1;
+        return \preg_match('{^' . $token . '/' . $token . '(?:\s*;\s*' . $token . '=' . $value . ')*$}', $type) === 1;
     }
 
     /**

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -3,6 +3,7 @@
 namespace Utopia\CloudEvents;
 
 use InvalidArgumentException;
+use JsonException;
 
 /**
  * CloudEvent class representing the CloudEvents v1.0 specification
@@ -162,6 +163,80 @@ class CloudEvent
         }
 
         return $array + $this->extensions;
+    }
+
+    /**
+     * Create CloudEvent from its JSON event format representation
+     *
+     * Binary payloads carried in the data_base64 member are decoded
+     * into data.
+     *
+     * @see https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md
+     *
+     * @param string $json
+     * @return self
+     * @throws InvalidArgumentException
+     */
+    public static function fromJson(string $json): self
+    {
+        try {
+            $decoded = \json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidArgumentException('Invalid CloudEvent JSON: ' . $e->getMessage(), 0, $e);
+        }
+
+        if (!\is_array($decoded)) {
+            throw new InvalidArgumentException('CloudEvent JSON must decode to an object');
+        }
+
+        if (\array_key_exists('data_base64', $decoded)) {
+            if (\array_key_exists('data', $decoded)) {
+                throw new InvalidArgumentException('CloudEvent must not contain both data and data_base64');
+            }
+
+            if (!\is_string($decoded['data_base64'])) {
+                throw new InvalidArgumentException('data_base64 must be a string');
+            }
+
+            $binary = \base64_decode($decoded['data_base64'], true);
+
+            if ($binary === false) {
+                throw new InvalidArgumentException('data_base64 must be valid Base64');
+            }
+
+            unset($decoded['data_base64']);
+            $decoded['data'] = $binary;
+        }
+
+        return self::fromArray($decoded);
+    }
+
+    /**
+     * Serialize the CloudEvent to the JSON event format
+     *
+     * String data that is not valid UTF-8 (and therefore cannot be
+     * carried in the data member) is emitted as the data_base64 member.
+     *
+     * @see https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md
+     *
+     * @param int $flags json_encode() flags
+     * @return string
+     * @throws InvalidArgumentException
+     */
+    public function toJson(int $flags = 0): string
+    {
+        $array = $this->toArray();
+
+        if (\is_string($this->data) && \preg_match('//u', $this->data) !== 1) {
+            unset($array['data']);
+            $array['data_base64'] = \base64_encode($this->data);
+        }
+
+        try {
+            return \json_encode($array, $flags | JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidArgumentException('Unable to encode CloudEvent as JSON: ' . $e->getMessage(), 0, $e);
+        }
     }
 
     /**

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -259,6 +259,10 @@ class CloudEvent
             throw new InvalidArgumentException('Event source is required');
         }
 
+        if (!self::isValidUriReference($this->source)) {
+            throw new InvalidArgumentException('Event source must be a valid URI-reference: ' . $this->source);
+        }
+
         if ($this->id === '') {
             throw new InvalidArgumentException('Event id is required');
         }
@@ -271,12 +275,24 @@ class CloudEvent
             throw new InvalidArgumentException('Event time must not be empty when present');
         }
 
+        if ($this->time !== null && !self::isValidRfc3339($this->time)) {
+            throw new InvalidArgumentException('Event time must be a valid RFC 3339 timestamp: ' . $this->time);
+        }
+
         if ($this->datacontenttype === '') {
             throw new InvalidArgumentException('Event datacontenttype must not be empty when present');
         }
 
+        if ($this->datacontenttype !== null && !self::isValidMediaType($this->datacontenttype)) {
+            throw new InvalidArgumentException('Event datacontenttype must be a valid RFC 2046 media type: ' . $this->datacontenttype);
+        }
+
         if ($this->dataschema === '') {
             throw new InvalidArgumentException('Event dataschema must not be empty when present');
+        }
+
+        if ($this->dataschema !== null && !self::isValidUri($this->dataschema)) {
+            throw new InvalidArgumentException('Event dataschema must be a valid URI: ' . $this->dataschema);
         }
 
         foreach ($this->extensions as $name => $value) {
@@ -288,6 +304,78 @@ class CloudEvent
         }
 
         return true;
+    }
+
+    /**
+     * Check that a timestamp adheres to RFC 3339
+     *
+     * @param string $time
+     * @return bool
+     */
+    private static function isValidRfc3339(string $time): bool
+    {
+        $pattern = '/^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(\.\d+)?([Zz]|[+-](\d{2}):(\d{2}))$/';
+
+        if (\preg_match($pattern, $time, $matches) !== 1) {
+            return false;
+        }
+
+        if (!\checkdate((int) $matches[2], (int) $matches[3], (int) $matches[1])) {
+            return false;
+        }
+
+        if ((int) $matches[4] > 23 || (int) $matches[5] > 59 || (int) $matches[6] > 60) {
+            return false;
+        }
+
+        if (isset($matches[9], $matches[10]) && ((int) $matches[9] > 23 || (int) $matches[10] > 59)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check that a string only uses characters RFC 3986 allows in a
+     * URI-reference and that every percent sign starts a valid
+     * percent-encoded triplet
+     *
+     * @param string $uri
+     * @return bool
+     */
+    private static function isValidUriReference(string $uri): bool
+    {
+        if (\preg_match('/^[A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=%]*$/', $uri) !== 1) {
+            return false;
+        }
+
+        return \preg_match('/%(?![0-9A-Fa-f]{2})/', $uri) !== 1;
+    }
+
+    /**
+     * Check that a string is an absolute URI (has a scheme) with valid
+     * URI characters
+     *
+     * @param string $uri
+     * @return bool
+     */
+    private static function isValidUri(string $uri): bool
+    {
+        return \preg_match('/^[A-Za-z][A-Za-z0-9+.\-]*:/', $uri) === 1 && self::isValidUriReference($uri);
+    }
+
+    /**
+     * Check that a string is an RFC 2046 media type such as
+     * "application/json" or "text/plain; charset=utf-8"
+     *
+     * @param string $type
+     * @return bool
+     */
+    private static function isValidMediaType(string $type): bool
+    {
+        $token = "[0-9A-Za-z!#$%&'*+.^_`|~-]+";
+
+        return \preg_match('{^' . $token . '/' . $token . '(\s*;.*)?$}', $type) === 1;
     }
 
     /**

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -610,8 +610,26 @@ class CloudEventTest extends TestCase
         $event = CloudEvent::fromJson($json);
 
         $this->assertEquals('user.created', $event->type);
-        $this->assertEquals(['userId' => '123'], $event->data);
+        $this->assertEquals((object) ['userId' => '123'], $event->data);
         $this->assertEquals('00-abc-def-01', $event->getExtension('traceparent'));
+    }
+
+    public function testFromJsonPreservesJsonDataTypes(): void
+    {
+        $json = '{"specversion":"1.0","type":"t","source":"s","id":"i","data":{"empty":{},"list":[]}}';
+
+        $restored = CloudEvent::fromJson($json)->toJson();
+
+        $this->assertStringContainsString('"empty":{}', $restored);
+        $this->assertStringContainsString('"list":[]', $restored);
+    }
+
+    public function testFromJsonRejectsArrayRoot(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CloudEvent JSON must decode to an object');
+
+        CloudEvent::fromJson('[{"specversion":"1.0","type":"t","source":"s","id":"i"}]');
     }
 
     public function testFromJsonInvalidJson(): void
@@ -683,7 +701,15 @@ class CloudEventTest extends TestCase
 
         $restored = CloudEvent::fromJson($original->toJson());
 
-        $this->assertEquals($original, $restored);
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->source, $restored->source);
+        $this->assertEquals($original->id, $restored->id);
+        $this->assertEquals($original->subject, $restored->subject);
+        $this->assertEquals($original->time, $restored->time);
+        $this->assertEquals($original->datacontenttype, $restored->datacontenttype);
+        $this->assertEquals($original->dataschema, $restored->dataschema);
+        $this->assertEquals($original->extensions, $restored->extensions);
+        $this->assertJsonStringEqualsJsonString($original->toJson(), $restored->toJson());
     }
 
     public function testRoundTrip(): void

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -522,6 +522,108 @@ class CloudEventTest extends TestCase
         $this->assertEquals($original->extensions, $restored->extensions);
     }
 
+    public function testValidateAcceptsValidFormats(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'https://example.com/user-service#section',
+            id: 'test-id',
+            time: '2025-11-07T10:00:00.123+05:30',
+            datacontenttype: 'text/plain; charset=utf-8',
+            dataschema: 'https://example.com/schemas/user.json'
+        );
+
+        $this->assertTrue($event->validate());
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'user-service',
+            id: 'test-id',
+            time: '2025-11-07T10:00:00Z'
+        );
+
+        $this->assertTrue($event->validate());
+    }
+
+    public function testValidateRejectsInvalidTime(): void
+    {
+        $invalid = ['not-a-time', '2025-11-07 10:00:00Z', '2025-13-07T10:00:00Z', '2025-11-07T25:00:00Z', '2025-11-07T10:00:00'];
+
+        foreach ($invalid as $time) {
+            $event = new CloudEvent(
+                type: 'test.event',
+                source: 'test-service',
+                id: 'test-id',
+                time: $time
+            );
+
+            try {
+                $event->validate();
+                $this->fail('Expected InvalidArgumentException for time: ' . $time);
+            } catch (InvalidArgumentException $e) {
+                $this->assertStringContainsString('RFC 3339', $e->getMessage());
+            }
+        }
+    }
+
+    public function testValidateRejectsInvalidSourceUri(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event source must be a valid URI-reference');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'not a uri',
+            id: 'test-id'
+        );
+
+        $event->validate();
+    }
+
+    public function testValidateRejectsInvalidPercentEncodingInSource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event source must be a valid URI-reference');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'service/%ZZ',
+            id: 'test-id'
+        );
+
+        $event->validate();
+    }
+
+    public function testValidateRejectsInvalidDatacontenttype(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event datacontenttype must be a valid RFC 2046 media type');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            datacontenttype: 'json'
+        );
+
+        $event->validate();
+    }
+
+    public function testValidateRejectsRelativeDataschema(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Event dataschema must be a valid URI');
+
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            dataschema: 'schemas/user.json'
+        );
+
+        $event->validate();
+    }
+
     public function testToJson(): void
     {
         $event = new CloudEvent(

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -653,17 +653,78 @@ class CloudEventTest extends TestCase
 
     public function testValidateRejectsInvalidDatacontenttype(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Event datacontenttype must be a valid RFC 2046 media type');
+        $invalid = ['json', 'text/plain;', 'text/plain; charset=', 'text/plain;;', 'text/plain; =utf-8'];
 
+        foreach ($invalid as $type) {
+            $event = new CloudEvent(
+                type: 'test.event',
+                source: 'test-service',
+                id: 'test-id',
+                datacontenttype: $type
+            );
+
+            try {
+                $event->validate();
+                $this->fail('Expected InvalidArgumentException for datacontenttype: ' . $type);
+            } catch (InvalidArgumentException $e) {
+                $this->assertStringContainsString('RFC 2046', $e->getMessage());
+            }
+        }
+    }
+
+    public function testValidateAcceptsQuotedMediaTypeParameter(): void
+    {
         $event = new CloudEvent(
             type: 'test.event',
             source: 'test-service',
             id: 'test-id',
-            datacontenttype: 'json'
+            datacontenttype: 'text/plain; charset="utf 8"'
         );
 
-        $event->validate();
+        $this->assertTrue($event->validate());
+    }
+
+    public function testValidateRejectsMalformedUriStructure(): void
+    {
+        $invalid = ['http://[invalid', 'http://exa mple.com', '://missing-scheme'];
+
+        foreach ($invalid as $source) {
+            $event = new CloudEvent(
+                type: 'test.event',
+                source: $source,
+                id: 'test-id'
+            );
+
+            try {
+                $event->validate();
+                $this->fail('Expected InvalidArgumentException for source: ' . $source);
+            } catch (InvalidArgumentException $e) {
+                $this->assertStringContainsString('URI-reference', $e->getMessage());
+            }
+        }
+    }
+
+    public function testValidateAcceptsStructuredUris(): void
+    {
+        $valid = [
+            'http://[2001:db8::1]:8080/path?q=1#frag',
+            'mailto:events@example.com',
+            'urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66',
+            '//example.com/cloudevents',
+            '/cloudevents/spec/pull/123',
+            'user-service',
+            '#fragment-only',
+        ];
+
+        foreach ($valid as $source) {
+            $event = new CloudEvent(
+                type: 'test.event',
+                source: $source,
+                id: 'test-id'
+            );
+
+            $this->assertTrue($event->validate(), 'Expected valid URI-reference: ' . $source);
+        }
     }
 
     public function testValidateRejectsRelativeDataschema(): void

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -653,7 +653,15 @@ class CloudEventTest extends TestCase
 
     public function testValidateRejectsInvalidDatacontenttype(): void
     {
-        $invalid = ['json', 'text/plain;', 'text/plain; charset=', 'text/plain;;', 'text/plain; =utf-8'];
+        $invalid = [
+            'json',
+            'text/plain;',
+            'text/plain; charset=',
+            'text/plain;;',
+            'text/plain; =utf-8',
+            "text/plain; charset=\"bad\nvalue\"",
+            "text/plain; charset=\"nul\x00byte\"",
+        ];
 
         foreach ($invalid as $type) {
             $event = new CloudEvent(
@@ -674,19 +682,30 @@ class CloudEventTest extends TestCase
 
     public function testValidateAcceptsQuotedMediaTypeParameter(): void
     {
-        $event = new CloudEvent(
-            type: 'test.event',
-            source: 'test-service',
-            id: 'test-id',
-            datacontenttype: 'text/plain; charset="utf 8"'
-        );
+        $valid = ['text/plain; charset="utf 8"', 'text/plain; charset="say \"hi\""'];
 
-        $this->assertTrue($event->validate());
+        foreach ($valid as $type) {
+            $event = new CloudEvent(
+                type: 'test.event',
+                source: 'test-service',
+                id: 'test-id',
+                datacontenttype: $type
+            );
+
+            $this->assertTrue($event->validate(), 'Expected valid media type: ' . $type);
+        }
     }
 
     public function testValidateRejectsMalformedUriStructure(): void
     {
-        $invalid = ['http://[invalid', 'http://exa mple.com', '://missing-scheme'];
+        $invalid = [
+            'http://[invalid',
+            'http://exa mple.com',
+            '://missing-scheme',
+            'http://[::1::]/path',
+            'http://[....]/schema',
+            'http://[gggg::1]/',
+        ];
 
         foreach ($invalid as $source) {
             $event = new CloudEvent(
@@ -708,6 +727,9 @@ class CloudEventTest extends TestCase
     {
         $valid = [
             'http://[2001:db8::1]:8080/path?q=1#frag',
+            'http://[::1]/events',
+            'http://[::ffff:192.0.2.1]/events',
+            'http://[v1.fe80::a+en1]/events',
             'mailto:events@example.com',
             'urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66',
             '//example.com/cloudevents',

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -522,6 +522,113 @@ class CloudEventTest extends TestCase
         $this->assertEquals($original->extensions, $restored->extensions);
     }
 
+    public function testToJson(): void
+    {
+        $event = new CloudEvent(
+            type: 'user.created',
+            source: 'https://example.com/user-service',
+            id: 'event-1',
+            time: '2025-11-07T10:00:00Z',
+            datacontenttype: 'application/json',
+            data: ['userId' => '123']
+        );
+
+        $decoded = json_decode($event->toJson(), true);
+
+        $this->assertEquals([
+            'specversion' => '1.0',
+            'type' => 'user.created',
+            'source' => 'https://example.com/user-service',
+            'id' => 'event-1',
+            'time' => '2025-11-07T10:00:00Z',
+            'datacontenttype' => 'application/json',
+            'data' => ['userId' => '123']
+        ], $decoded);
+    }
+
+    public function testFromJson(): void
+    {
+        $json = '{"specversion":"1.0","type":"user.created","source":"user-service","id":"event-1","data":{"userId":"123"},"traceparent":"00-abc-def-01"}';
+
+        $event = CloudEvent::fromJson($json);
+
+        $this->assertEquals('user.created', $event->type);
+        $this->assertEquals(['userId' => '123'], $event->data);
+        $this->assertEquals('00-abc-def-01', $event->getExtension('traceparent'));
+    }
+
+    public function testFromJsonInvalidJson(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid CloudEvent JSON');
+
+        CloudEvent::fromJson('{not json');
+    }
+
+    public function testFromJsonNonObject(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CloudEvent JSON must decode to an object');
+
+        CloudEvent::fromJson('"just a string"');
+    }
+
+    public function testJsonBinaryDataRoundTrip(): void
+    {
+        $binary = "\x89PNG\r\n\x1a\n\x00\x01\x02\x80\xff";
+
+        $event = new CloudEvent(
+            type: 'image.uploaded',
+            source: 'storage',
+            id: 'event-1',
+            datacontenttype: 'image/png',
+            data: $binary
+        );
+
+        $decoded = json_decode($event->toJson(), true);
+
+        $this->assertArrayNotHasKey('data', $decoded);
+        $this->assertEquals(base64_encode($binary), $decoded['data_base64']);
+
+        $restored = CloudEvent::fromJson($event->toJson());
+
+        $this->assertEquals($binary, $restored->data);
+    }
+
+    public function testFromJsonRejectsDataAndDataBase64(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CloudEvent must not contain both data and data_base64');
+
+        CloudEvent::fromJson('{"specversion":"1.0","type":"t","source":"s","id":"i","data":"x","data_base64":"eA=="}');
+    }
+
+    public function testFromJsonRejectsInvalidBase64(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('data_base64 must be valid Base64');
+
+        CloudEvent::fromJson('{"specversion":"1.0","type":"t","source":"s","id":"i","data_base64":"!!!not-base64!!!"}');
+    }
+
+    public function testJsonRoundTrip(): void
+    {
+        $original = (new CloudEvent(
+            type: 'payment.processed',
+            source: 'https://example.com/payments',
+            id: 'event-123',
+            subject: 'payment-xyz',
+            time: '2025-11-07T10:00:00Z',
+            datacontenttype: 'application/json',
+            dataschema: 'https://example.com/schemas/payment.json',
+            data: ['paymentId' => 'xyz']
+        ))->withExtension('traceparent', '00-abc-def-01');
+
+        $restored = CloudEvent::fromJson($original->toJson());
+
+        $this->assertEquals($original, $restored);
+    }
+
     public function testRoundTrip(): void
     {
         $original = new CloudEvent(


### PR DESCRIPTION
## What

`validate()` now enforces the CloudEvents v1.0 attribute type constraints that were previously unchecked:

- `time` must be a valid RFC 3339 timestamp (date validity, clock ranges and UTC offset ranges are verified; leap seconds and fractional seconds are accepted)
- `source` must match the RFC 3986 URI-reference grammar (scheme, authority with userinfo/host/port including IP literals, path variants, query, fragment)
- `dataschema` must match the RFC 3986 URI grammar (absolute, scheme required, per the spec's URI type)
- `datacontenttype` must be an RFC 2046 media type with every parameter a `token=token` or `token=quoted-string` pair (e.g. `application/json`, `text/plain; charset=utf-8`)

## Why

The spec defines these attribute types as MUST-level constraints; previously `validate()` accepted `time: "not-a-time"` or `source: "not a uri"`.

Stacked on #10 — part 6/7 of a spec-compliance PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)