### PR TITLE
feat: add now() helper for RFC 3339 timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $event = new CloudEvent(
     source: 'https://example.com/user-service',
     id: uniqid(),
     subject: 'user-123',
-    time: date('c'),
+    time: CloudEvent::now(),
     datacontenttype: 'application/json',
     data: [
         'userId' => '123',
@@ -50,6 +50,8 @@ $event = new CloudEvent(
 ```
 
 When using the constructor, only `type`, `source` and `id` are required. All other attributes are optional. Arrays passed to `CloudEvent::fromArray()` must also carry an explicit `specversion`.
+
+`CloudEvent::now()` returns the current time as an RFC 3339 UTC timestamp with millisecond precision (e.g., `2025-11-07T10:00:00.123Z`), ready to use as the `time` attribute.
 
 ### Converting to Array
 

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -2,6 +2,8 @@
 
 namespace Utopia\CloudEvents;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use InvalidArgumentException;
 use JsonException;
 
@@ -11,6 +13,14 @@ use JsonException;
  */
 class CloudEvent
 {
+    /**
+     * RFC 3339 (UTC, millisecond precision) format string.
+     *
+     * PHP's DATE_ATOM renders UTC as "+00:00" and carries no sub-second
+     * part, so it is not used here.
+     */
+    public const TIME_FORMAT = 'Y-m-d\TH:i:s.v\Z';
+
     /**
      * Names reserved for core context attributes, which extension
      * attributes must not use.
@@ -53,6 +63,19 @@ class CloudEvent
         public readonly ?string $dataschema = null,
         public readonly array $extensions = []
     ) {
+    }
+
+    /**
+     * Current time as an RFC 3339 UTC timestamp with milliseconds
+     *
+     * Produces e.g. "2025-11-07T10:00:00.123Z", which is what the time
+     * attribute expects.
+     *
+     * @return string
+     */
+    public static function now(): string
+    {
+        return (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format(self::TIME_FORMAT);
     }
 
     /**

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -431,6 +431,25 @@ class CloudEventTest extends TestCase
         $this->assertTrue($event->validate());
     }
 
+    public function testNow(): void
+    {
+        $time = CloudEvent::now();
+
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/', $time);
+    }
+
+    public function testNowIsValidEventTime(): void
+    {
+        $event = new CloudEvent(
+            type: 'test.event',
+            source: 'test-service',
+            id: 'test-id',
+            time: CloudEvent::now()
+        );
+
+        $this->assertTrue($event->validate());
+    }
+
     public function testExtensions(): void
     {
         $event = new CloudEvent(


### PR DESCRIPTION
## What

Adds `CloudEvent::now()`, a static helper that returns the current time as an RFC 3339 UTC timestamp with millisecond precision (e.g. `2025-11-07T10:00:00.123Z`), ready to use as the `time` attribute:

```php
$event = new CloudEvent(
    type: 'com.example.user.created',
    source: 'https://example.com/user-service',
    id: uniqid(),
    time: CloudEvent::now(),
);
```

The format string is exposed as the public `CloudEvent::TIME_FORMAT` constant.

## Why

Producing a spec-correct `time` value currently requires callers to know RFC 3339 details. `DATE_ATOM` is deliberately not used: it renders UTC as `+00:00` and carries no sub-second part.

## Notes

- Tests cover the output format and that `now()` passes `validate()`'s RFC 3339 check.
- README Quick Start updated to use the helper instead of `date('c')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)