### PR TITLE
feat: validate extension attributes in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ $event->extensions['traceparent'] ?? null; // '00-4bf9...'
 $event->extensions;                        // all extension attributes
 ```
 
-Extension names must consist of lowercase letters and digits only, and values must be booleans, integers or strings. `CloudEvent` instances are immutable readonly value objects.
+Extension names must consist of lowercase letters and digits only, and values must be booleans, integers or strings. These rules are enforced at construction — an invalid extension attribute makes the constructor (and therefore `fromArray()` and `fromJson()`) throw, so a `CloudEvent` instance never carries invalid extensions. `CloudEvent` instances are immutable readonly value objects.
 
 ### Validating a CloudEvent
 
-`validate()` checks the event against the spec: the spec version is supported, `type`, `source` and `id` are non-empty, optional attributes are non-empty when present, and extension attributes follow the naming and type rules.
+`validate()` checks the event against the spec: the spec version is supported, `type`, `source` and `id` are non-empty, and optional attributes are non-empty when present. Extension attributes are already validated at construction.
 
 ```php
 try {

--- a/src/CloudEvents/CloudEvent.php
+++ b/src/CloudEvents/CloudEvent.php
@@ -50,6 +50,7 @@ class CloudEvent
      * @param mixed $data Optional event payload of any type
      * @param string|null $dataschema Optional URI identifying the schema that data adheres to
      * @param array<string, mixed> $extensions Extension attributes (lowercase alphanumeric names, boolean/integer/string values)
+     * @throws InvalidArgumentException When an extension attribute has an invalid name or value
      */
     public function __construct(
         public readonly string $type,
@@ -63,6 +64,13 @@ class CloudEvent
         public readonly ?string $dataschema = null,
         public readonly array $extensions = []
     ) {
+        foreach ($this->extensions as $name => $value) {
+            self::assertValidExtensionName((string) $name);
+
+            if (!\is_bool($value) && !\is_int($value) && !\is_string($value)) {
+                throw new InvalidArgumentException('Extension attribute "' . $name . '" must be a boolean, integer or string');
+            }
+        }
     }
 
     /**
@@ -97,20 +105,12 @@ class CloudEvent
             throw new InvalidArgumentException('Unsupported CloudEvents spec version: ' . $array['specversion']);
         }
 
-        $extensions = \array_diff_key($array, \array_flip(self::RESERVED_ATTRIBUTES));
-
-        foreach ($extensions as $name => $value) {
-            if ($value === null) {
-                unset($extensions[$name]);
-                continue;
-            }
-
-            self::assertValidExtensionName((string) $name);
-
-            if (!\is_bool($value) && !\is_int($value) && !\is_string($value)) {
-                throw new InvalidArgumentException('Extension attribute "' . $name . '" must be a boolean, integer or string');
-            }
-        }
+        // Null values mean the attribute is unset; the constructor
+        // validates whatever remains.
+        $extensions = \array_filter(
+            \array_diff_key($array, \array_flip(self::RESERVED_ATTRIBUTES)),
+            fn (mixed $value): bool => $value !== null
+        );
 
         return new self(
             type: $array['type'],
@@ -284,13 +284,8 @@ class CloudEvent
             throw new InvalidArgumentException('Event dataschema must not be empty when present');
         }
 
-        foreach ($this->extensions as $name => $value) {
-            self::assertValidExtensionName((string) $name);
-
-            if (!\is_bool($value) && !\is_int($value) && !\is_string($value)) {
-                throw new InvalidArgumentException('Extension attribute "' . $name . '" must be a boolean, integer or string');
-            }
-        }
+        // Extension attributes need no checks here: the constructor
+        // validates them, and readonly keeps the invariant intact.
 
         return true;
     }

--- a/tests/CloudEvents/CloudEventTest.php
+++ b/tests/CloudEvents/CloudEventTest.php
@@ -551,49 +551,43 @@ class CloudEventTest extends TestCase
         $this->assertArrayNotHasKey('traceparent', $event->toArray());
     }
 
-    public function testValidateRejectsInvalidExtensionName(): void
+    public function testConstructorRejectsInvalidExtensionName(): void
     {
-        $event = new CloudEvent(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute name must contain only lowercase letters and digits');
+
+        new CloudEvent(
             type: 'test.event',
             source: 'test-service',
             id: 'test-id',
             extensions: ['Trace_Parent' => 'value']
         );
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Extension attribute name must contain only lowercase letters and digits');
-
-        $event->validate();
     }
 
-    public function testValidateRejectsReservedExtensionName(): void
+    public function testConstructorRejectsReservedExtensionName(): void
     {
-        $event = new CloudEvent(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute name conflicts with a core attribute: data');
+
+        new CloudEvent(
             type: 'test.event',
             source: 'test-service',
             id: 'test-id',
             extensions: ['data' => 'value']
         );
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Extension attribute name conflicts with a core attribute: data');
-
-        $event->validate();
     }
 
-    public function testValidateRejectsInvalidExtensionValue(): void
+    public function testConstructorRejectsInvalidExtensionValue(): void
     {
-        $event = new CloudEvent(
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Extension attribute "myext" must be a boolean, integer or string');
+
+        new CloudEvent(
             type: 'test.event',
             source: 'test-service',
             id: 'test-id',
             extensions: ['myext' => ['nested' => 'array']]
         );
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Extension attribute "myext" must be a boolean, integer or string');
-
-        $event->validate();
     }
 
     public function testExtensionRoundTrip(): void


### PR DESCRIPTION
## What

Extension attribute names and value types are now validated when a `CloudEvent` is constructed:

```php
new CloudEvent(
    type: 'test.event',
    source: 'test-service',
    id: 'test-id',
    extensions: ['Trace_Parent' => 'value'], // throws InvalidArgumentException immediately
);
```

## Why

Previously the constructor accepted any `extensions` array and the problem only surfaced when `validate()` happened to be called — an invalid event could travel through the system before failing. Since `$extensions` is `readonly` and every path into an instance (`fromArray()`, `fromJson()`) goes through the constructor, checking once at construction guarantees an instance never carries an invalid extension.

## Notes

- The now-redundant checks in `fromArray()` and `validate()` are removed; `fromArray()` still treats `null` extension values as unset before constructing. Exception messages are unchanged, and the existing `fromArray` rejection tests pass as-is against the constructor-thrown exceptions.
- Behavior change: constructing with invalid extensions now throws immediately instead of at `validate()` time. The `testValidateRejects*Extension*` tests were reworked into their constructor-level equivalents (`testConstructorRejectsInvalidExtensionName`/`ReservedExtensionName`/`InvalidExtensionValue`).
- Follows the no-getters/no-withers convention: extensions are passed at construction and read via the readonly `extensions` property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)